### PR TITLE
필수 - [1411] 비슷한 단어, [9019] DSLR (정현명)

### DIFF
--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+qweqewewq

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-qweqewewq

--- a/정현명/Main_1411.java
+++ b/정현명/Main_1411.java
@@ -15,7 +15,7 @@ public class Main_1411 {
 		numbers = new int[2];
 		strs = new String[N];
 		for(int i=0;i<N;i++) {
-			strs[i] = br.readLine();
+			strs[i] = mapping(br.readLine());
 		}
 		
 		answer = 0;
@@ -27,10 +27,9 @@ public class Main_1411 {
 	public static void combi(int start, int cnt) {
 		if(cnt == 2) {
 			
-			if(mapping(strs[numbers[0]]).equals(mapping(strs[numbers[1]]))) {
+			if(strs[numbers[0]].equals(strs[numbers[1]])) {
 				answer++;
 			}
-			
 			return;
 		}
 		

--- a/정현명/Main_1411.java
+++ b/정현명/Main_1411.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Main_1411 {
+	static int answer;
+	static int N;
+	static int[] numbers;
+	static String[] strs;
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		numbers = new int[2];
+		strs = new String[N];
+		for(int i=0;i<N;i++) {
+			strs[i] = br.readLine();
+		}
+		
+		answer = 0;
+		combi(0,0);
+		System.out.println(answer);
+	}
+	
+	
+	public static void combi(int start, int cnt) {
+		if(cnt == 2) {
+			
+			if(mapping(strs[numbers[0]]).equals(mapping(strs[numbers[1]]))) {
+				answer++;
+			}
+			
+			return;
+		}
+		
+		for(int i=start; i<N;i++) {
+			numbers[cnt] = i;
+			combi(i+1,cnt+1);
+		}
+	}
+	
+	
+	public static String mapping(String str) {
+		String answer = "";
+		
+		Map<Character,Character> map = new HashMap<>();
+		char c='a';
+		for(int i=0;i<str.length();i++) {
+			if(!map.containsKey(str.charAt(i))) {
+				map.put(str.charAt(i), (char)(c++));
+			}
+			answer+=map.get(str.charAt(i));
+		}
+		
+		return answer;
+	}
+
+}

--- a/정현명/Main_9019.java
+++ b/정현명/Main_9019.java
@@ -1,0 +1,127 @@
+	import java.io.BufferedReader;
+	import java.io.IOException;
+	import java.io.InputStreamReader;
+	import java.util.Arrays;
+	import java.util.LinkedList;
+	import java.util.Queue;
+	import java.util.StringTokenizer;
+	
+	public class Main_9019 {
+	
+		static char[] chars = {'D','S','L','R'};
+		public static void main(String[] args) throws IOException{
+			BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+			int T = Integer.parseInt(br.readLine());
+			
+			StringTokenizer st;
+			while(T-->0) {
+				st = new StringTokenizer(br.readLine());
+				
+				int A = Integer.parseInt(st.nextToken());
+				int B = Integer.parseInt(st.nextToken());
+				
+				bfs(A,B);
+			}
+		}
+		
+		
+		public static void bfs(int start, int target) {
+			
+			
+			int parent[] = new int[10000];
+			Arrays.fill(parent, -1);
+			char commands[] = new char[10000];
+			
+			Queue<Integer> que = new LinkedList<>();
+			que.add(start);
+			
+			while(!que.isEmpty()) {
+				
+				int now = que.poll();
+				
+				if(parent[target] != -1) { // target에 도달한 적이 있으면 탈출 
+					break;
+				}
+				
+				for(int i=0;i<4;i++) {
+					int res = cal(now, i);
+					if(parent[res] == -1) {
+						parent[res] = now;
+						commands[res] = chars[i];
+						que.add(res);
+					}
+				}
+			}
+			
+			StringBuilder sb = new StringBuilder();
+			
+			while(target != start) {
+				sb.append(commands[target]);
+				target = parent[target];
+			}
+			
+			sb = sb.reverse();
+			System.out.println(sb);
+			
+		}
+		
+		public static int cal(int n, int command) {
+			
+			int res = 0;
+			
+			switch(command) {
+			case 0:
+				res = n*2 % 10000;
+				break;
+			case 1:
+				res = n == 0? 9999 : n-1;
+				break;
+			case 2:
+				res = (n / 1000) + (n % 1000) * 10;
+				break;
+			case 3:
+				res = (n / 10) + (n % 10 * 1000);
+				break;
+			}
+			
+			return res;
+		}
+	}
+	
+//	public static class DSLR {
+//	int num;
+//	String commands;
+//	
+//	public DSLR(int num, String commands) {
+//		this.num = num;
+//		this.commands = commands;
+//	}
+//	
+//}
+//
+//public static void bfs(int start, int target) {
+//	
+//	boolean[] visited = new boolean[10000];
+//	
+//	Queue<DSLR> que = new LinkedList<>();
+//	que.add(new DSLR(start,""));
+//	visited[start]= true;
+//	while(!que.isEmpty()) {
+//		
+//		DSLR data = que.poll();
+//		if(data.num == target) {
+//			System.out.println(data.commands);
+//			break;
+//		}
+//		
+//		
+//		for(int i=0;i<4;i++) {
+//			int res = cal(data.num, i);
+//			if(!visited[res]) {
+//				visited[res]= true; 
+//				que.add(new DSLR(res, data.commands+chars[i]));
+//			}
+//		}
+//	}
+//	
+//}


### PR DESCRIPTION
[1411] 비슷한 단어
문자열을 받자마자 알파벳 순서대로 매핑 해주는 함수로 매핑한 후, 조합으로 모든 문자열을 짝지어 비교했습니다.
zxcv => abcd
qwer => abcd
zxcz => abca


[9019] DSLR
현재 수와 문자열을 저장하는 클래스를 만들고
bfs에서 큐에 객체를 넣어 탐색했는데 시간초과는 걸리진 않지만 오래 걸렸습니다.
참고로 위 방법에서 방문처리를 어디서 하느냐에 따라 통과 되기도, 안되기도 합니다.... 큐에서 받은 직후 방문처리를 하는 것보단 DSLR 반복문에서 방문처리를 하는 것이 더 빠릅니다 ( ex) D 연산 후 바로 방문처리 해서 SLR 중 이와 겹치는 것 제외 )

그래서 고수의 방법을 참조해서 문자열을 저장하지 않고 역순으로 명령어를 찾아내는 알고리즘으로 다시 구현했습니다